### PR TITLE
Add implementation guide for observability framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://rust-doc.vector.dev/">Rust Crate Docs</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="docs/guides/development_best_practices.md">Development Guide</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="docs/guides/pull_request_workflow.md">Pull Request Guide</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
-    <a href="docs/guides/vector_based_observability_reduction_framework.md">Observability Framework</a>
+    <a href="docs/guides/vector_based_observability_reduction_framework.md">Observability Framework</a>&nbsp;&bull;&nbsp;&nbsp;<a href="docs/guides/observability_reduction_framework_implementation_guide.md">Implementation Guide</a>
   </strong>
 </p>
 <p align="center">

--- a/docs/guides/observability_reduction_framework_implementation_guide.md
+++ b/docs/guides/observability_reduction_framework_implementation_guide.md
@@ -1,0 +1,53 @@
+# Observability Reduction Framework Implementation Guide
+
+This guide lists incremental tasks for implementing the
+[Vector-Based Pluggable Observability Reduction Framework](vector_based_observability_reduction_framework.md).
+It references [ARCHITECTURE.md](../ARCHITECTURE.md) and starts with simple placeholders.
+
+Each step includes a verification hint so it can be fed to Codex.
+
+## Tasks
+
+1. **Project setup**
+   - Fork the repository and run `scripts/environment/prepare.sh`.
+   - **Verify**: `cargo --version` prints a valid version.
+
+2. **Create baseline module**
+   - Add a `baseline` crate containing a stub `build_baseline()` that returns `Ok(())`.
+   - Write a unit test calling the function.
+   - **Verify**: `cargo test -p baseline` succeeds.
+
+3. **Add anomaly detection placeholder**
+   - Introduce an `anomaly` module with `detect_anomalies()` reading a mock dataset.
+   - **Verify**: a unit test loads the mock data and `cargo test -p anomaly` passes.
+
+4. **Implement hypothesis/LLM evaluation stub**
+   - Create a module `hypothesis` with an `evaluate()` function returning `"todo"`.
+   - **Verify**: run module tests and confirm the output string.
+
+5. **Add self-healing action skeleton**
+   - Provide an `actions` module exposing `restart_service()` in simulation mode.
+   - **Verify**: tests check that the action logs an intent but does not execute.
+
+6. **GitHub issue escalation prototype**
+   - Implement a `github_escalation` module using `octocrab` with a fake token.
+   - **Verify**: tests assert the generated HTTP payload without performing a call.
+
+7. **Configuration wiring**
+   - Extend `config` with sections for the new modules.
+   - **Verify**: `cargo build` succeeds with the configuration fields present.
+
+8. **Example pipeline with placeholders**
+   - Compose a sample Vector config that wires all modules together.
+   - **Verify**: run Vector and check log output from each placeholder.
+
+9. **Testing framework**
+   - Add a suite under `tests/` exercising the example pipeline.
+   - **Verify**: `cargo test` at workspace root passes.
+
+10. **Iterate and replace placeholders**
+    - Gradually implement real logic in each module and update tests.
+    - **Verify**: the full test suite continues to pass and the pipeline behaves
+      as expected.
+
+Follow these tasks sequentially to build a working observability reduction framework.


### PR DESCRIPTION
## Summary
- document step-by-step implementation guide for the observability reduction framework
- link the new guide from the main README

## Testing
- `markdownlint docs/guides/observability_reduction_framework_implementation_guide.md`
- `make check-markdown` *(fails: existing docs violate lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68534e75a56883278f3e2710108c5c9a